### PR TITLE
fixlayoutdevisepages

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-4 mb-4">
-  <h2><%= t(".resend_confirmation_instructions") %></h2>
+  <h2 class="pb-5 grey-dark"><%= t(".resend_confirmation_instructions") %></h2>
 
   <%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
     <%= f.error_notification %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-4 mb-4">
-  <h2><%= t(".change_your_password") %></h2>
+  <h2 class="pb-5 grey-dark"><%= t(".change_your_password") %></h2>
 
   <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
     <%= f.error_notification %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-4 mb-4">
-  <h2><%= t(".forgot_your_password") %></h2>
+  <h2 class="pb-5 grey-dark"><%= t(".forgot_your_password") %></h2>
 
   <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= f.error_notification %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,6 @@
 <div class="container mt-4 mb-4">
-  <h2 class="mb-4"><%= t(".title", resource: resource.model_name.human) %></h2>
+  <!-- <h2 class="mb-4"><%= t(".title", resource: resource.model_name.human) %></h2> -->
+  <h2 class="pb-5 grey-dark">Mise à jour de mon compte client</h2>
 
   <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, defaults: { input_html: { class: 'form-edit-account' } }) do |f| %>
     <%= f.error_notification %>
@@ -26,6 +27,7 @@
                   required: false,
                   input_html: { autocomplete: "new-password" } %>
       <%= f.input :password_confirmation,
+                  hint: t(".leave_blank_if_you_don_t_want_to_change_it"),
                   required: false,
                   input_html: { autocomplete: "new-password" } %>
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <div class="container mt-5 mb-5">
-  <h2 class="pb-3 grey-dark"><%= t(".sign_up") %></h2>
+  <h2 class="pb-5 grey-dark"><%= t(".sign_up") %></h2>
 
   <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <%= f.error_notification %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -130,7 +130,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  config.allow_unconfirmed_access_for = 7.days
+  config.allow_unconfirmed_access_for = nil
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -58,10 +58,11 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
     b.use :input, class: 'form-control', error_class: 'is-invalid'
     # , valid_class: 'is-valid' cf https://stackoverflow.com/questions/51848531/rails-simple-form-gem-is-adding-a-green-border-to-inputs-that-are-pre-populated
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
-    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+
   end
 
   # vertical input for boolean

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -7,7 +7,7 @@ en:
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
-      already_authenticated: "You are already signed in."
+      already_authenticated: "You are already sigwned in."
       inactive: "Your account is not activated yet."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."
@@ -18,15 +18,15 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "goutsdfruits.fr - Confirmation instructions"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "goutsdfruits.fr - Reset password instructions"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "goutsdfruits.fr - Unlock instructions"
       email_changed:
-        subject: "Email Changed"
+        subject: "goutsdfruits.fr - Email Changed"
       password_change:
-        subject: "Password Changed"
+        subject: "goutsdfruits.fr - Password Changed"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -18,15 +18,15 @@ fr:
       unconfirmed: "Vous devez valider votre compte pour continuer."
     mailer:
       confirmation_instructions:
-        subject: "Instructions de confirmation"
+        subject: "goutsdfruits.fr - Instructions de confirmation"
       reset_password_instructions:
-        subject: "Instructions pour changer le mot de passe"
+        subject: "goutsdfruits.fr - Instructions pour changer le mot de passe"
       unlock_instructions:
-        subject: "Instructions pour déverrouiller le compte"
+        subject: "goutsdfruits.fr - Instructions pour déverrouiller le compte"
       email_changed:
-        subject: "Votre adresse e-mail a été modifiée avec succès"
+        subject: "goutsdfruits.fr - Votre adresse e-mail a été modifiée avec succès"
       password_change:
-        subject: "Votre mot de passe a été modifié avec succès"
+        subject: "goutsdfruits.fr - Votre mot de passe a été modifié avec succès"
     omniauth_callbacks:
       failure: "Nous n'avons pas pu vous authentifier via %{kind} : '%{reason}'."
       success: "Authentifié avec succès via %{kind}."


### PR DESCRIPTION
Devise pages : couleur bleue supprimée sur les titres (pas un lien)
Initializers/devise.rb :  config.allow_unconfirmed_access_for = nil (pas besoin de confirmer le compte pour l'utiliser)
Initializers/simple_form_bootrstrap : hint placé au dessus du champ input
locales/devise en & fr : ajout dans l'objet des mails "goutsdfruits.fr"