### PR TITLE
display methods for product index delocalized in helper modules

### DIFF
--- a/app/helpers/product_classes_helper.rb
+++ b/app/helpers/product_classes_helper.rb
@@ -1,0 +1,28 @@
+module ProductClassesHelper
+
+# METHODES DE CLASSE DU MODELE PRODUIT UTILISEES POUR LES FILTRES DE L'INDEX PRODUITS
+
+  def types_to_display
+    types_to_display = Product.all.map(&:product_type).uniq.sort_by { |word| word.downcase }
+    # on n'affiche ici que les types existants avec quantité positive dans les produits de la db contrairement à self.types qui contient tous les types potentiels
+    #itération sur chaque produit, les doublons sont  éliminés grâce au .uniq.
+  # &:product_type est un raccourci syntaxtique qui correspond à : Product.all.map do |product| product.fruit_product
+    types_to_display.unshift('Type')
+  end
+
+  def types_to_display_positive_stock
+    types_to_display = Product.all.select { |product| product.total_remaining_quantity > 0 }.map(&:product_type).uniq.sort_by { |word| word.downcase }
+    types_to_display.unshift('Type')
+  end
+
+  def fruits_to_display
+    fruits_to_display = Product.all.map(&:product_fruit).uniq.sort_by { |word| word.downcase }
+    fruits_to_display.unshift('Fruit')
+  end
+
+  def fruits_to_display_positive_stock
+    fruits_to_display = Product.all.select { |product| product.total_remaining_quantity > 0 }.map(&:product_fruit).uniq.sort_by { |word| word.downcase }
+    fruits_to_display.unshift('Fruit')
+  end
+
+end

--- a/app/helpers/product_instances_helper.rb
+++ b/app/helpers/product_instances_helper.rb
@@ -1,0 +1,72 @@
+module ProductInstancesHelper
+
+# METHODES D'INSTANCE DU MODELE PRODUIT UTILISEES POUR LES FILTRES DE L'INDEX PRODUITS
+
+  def display_price(user, type_price)
+    price = # raccourci Ruby pour stocker le résultat des conditions ci-dessous dans une variable price
+      if user && user.role == "admin"
+        if type_price == "magasin"
+          unit_price_cents_shop
+        else
+          unit_price_cents
+        end
+      elsif user && user.segment == 'magasin'
+        unit_price_cents_shop_ET
+      else
+        unit_price_cents
+      end
+    if price
+      price/100.to_f
+    else
+      nil # couvre le cas où il n'y a pas de unit_price_cent_shop (cas des produits non vendus aux magasins)
+    end
+  end
+
+  def display_quantity(user, type_price, product)
+    display_quantity =
+      if user && user.role == "admin"
+        if type_price == "magasin"
+          product.total_remaining_quantity * product.unit_measure_quantity / product.unit_measure_quantity_shop
+        else
+          product.total_remaining_quantity
+        end
+      else
+        ""
+      end
+  end
+
+  def display_unit_measure_quantity(user, type_price, product)
+    display_unit_measure_quantity =
+    if (user && user.role == "admin" && type_price == "magasin") || (user && user.segment == 'magasin')
+      unless product.unit_measure_quantity_shop >= 1000 && product.unit_measure = "g"
+        product.unit_measure_quantity_shop
+      else
+        product.unit_measure_quantity_shop / 1000
+      end
+    else
+      unless product.unit_measure_quantity >= 1000 && product.unit_measure = "g"
+        product.unit_measure_quantity
+      else
+        product.unit_measure_quantity / 1000
+      end
+    end
+  end
+
+  def display_unit_measure(user, type_price, product)
+    display_unit_measure =
+    if (user && user.role == "admin" && type_price == "magasin") || (user && user.segment == 'magasin')
+      unless product.unit_measure_quantity_shop >= 1000 && product.unit_measure = "g"
+        product.unit_measure
+      else
+        "kg"
+      end
+    else
+      unless product.unit_measure_quantity >= 1000 && product.unit_measure = "g"
+        product.unit_measure
+      else
+        "kg"
+      end
+    end
+  end
+
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,6 @@
 class Product < ApplicationRecord
+  include ProductInstancesHelper
+  extend ProductClassesHelper
 
   has_many :product_lots
   has_many :order_lines
@@ -141,99 +143,6 @@ class Product < ApplicationRecord
 
   def self.fruits
     ["cassis", "cerise", "coing", "courge", "fraise", "framboise", "groseille", "menthe", "mix", "mûre", "noisette", "poire", "pomme", "prune", "pêche", "raisin", "rhubarbe", "sureau"]
-  end
-
-  # METHODES DEFINISSANT LES FILTRES DE L'INDEX PRODUITS
-  # les méthodes ci-dessous répondent à une logique d'affichage uniquement donc pourraient être mises dans un helper plutôt
-
-  def self.types_to_display
-    types_to_display = Product.all.map(&:product_type).uniq.sort_by { |word| word.downcase }
-    # on n'affiche ici que les types existants avec quantité positive dans les produits de la db contrairement à self.types qui contient tous les types potentiels
-    #itération sur chaque produit, les doublons sont  éliminés grâce au .uniq.
-  # &:product_type est un raccourci syntaxtique qui correspond à : Product.all.map do |product| product.fruit_product
-    types_to_display.unshift('Type')
-  end
-
-  def self.types_to_display_positive_stock
-    types_to_display = Product.all.select { |product| product.total_remaining_quantity > 0 }.map(&:product_type).uniq.sort_by { |word| word.downcase }
-    types_to_display.unshift('Type')
-  end
-
-  def self.fruits_to_display
-    fruits_to_display = Product.all.map(&:product_fruit).uniq.sort_by { |word| word.downcase }
-    fruits_to_display.unshift('Fruit')
-  end
-
-  def self.fruits_to_display_positive_stock
-    fruits_to_display = Product.all.select { |product| product.total_remaining_quantity > 0 }.map(&:product_fruit).uniq.sort_by { |word| word.downcase }
-    fruits_to_display.unshift('Fruit')
-  end
-
-  def display_price(user, type_price)
-    price = # raccourci Ruby pour stocker le résultat des conditions ci-dessous dans une variable price
-      if user && user.role == "admin"
-        if type_price == "magasin"
-          unit_price_cents_shop
-        else
-          unit_price_cents
-        end
-      elsif user && user.segment == 'magasin'
-        unit_price_cents_shop_ET
-      else
-        unit_price_cents
-      end
-    if price
-      price/100.to_f
-    else
-      nil # couvre le cas où il n'y a pas de unit_price_cent_shop (cas des produits non vendus aux magasins)
-    end
-  end
-
-  def display_quantity(user, type_price, product)
-    display_quantity =
-      if user && user.role == "admin"
-        if type_price == "magasin"
-          product.total_remaining_quantity * product.unit_measure_quantity / product.unit_measure_quantity_shop
-        else
-          product.total_remaining_quantity
-        end
-      else
-        ""
-      end
-  end
-
-  def display_unit_measure_quantity(user, type_price, product)
-    display_unit_measure_quantity =
-    if (user && user.role == "admin" && type_price == "magasin") || (user && user.segment == 'magasin')
-      unless product.unit_measure_quantity_shop >= 1000 && product.unit_measure = "g"
-        product.unit_measure_quantity_shop
-      else
-        product.unit_measure_quantity_shop / 1000
-      end
-    else
-      unless product.unit_measure_quantity >= 1000 && product.unit_measure = "g"
-        product.unit_measure_quantity
-      else
-        product.unit_measure_quantity / 1000
-      end
-    end
-  end
-
-  def display_unit_measure(user, type_price, product)
-    display_unit_measure =
-    if (user && user.role == "admin" && type_price == "magasin") || (user && user.segment == 'magasin')
-      unless product.unit_measure_quantity_shop >= 1000 && product.unit_measure = "g"
-        product.unit_measure
-      else
-        "kg"
-      end
-    else
-      unless product.unit_measure_quantity >= 1000 && product.unit_measure = "g"
-        product.unit_measure
-      else
-        "kg"
-      end
-    end
   end
 
 end


### PR DESCRIPTION
product_classes_helper.rb: moved class methods from product model that are used for displaying purposes in the product index view
product_instances_helper.rb: moved instance methods from product model that are used for displaying purposes in the product index view
models/product.rb: 
-> now includes ProductInstancesHelper and extends ProductClassesHelper
-> display methods moved to the 2 module helpers above