### PR TITLE
all emails now are background jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'cloudinary', '~> 1.12.0'
 gem 'caxlsx'
 gem 'caxlsx_rails'
 gem 'pg_search'
+gem 'sucker_punch'
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sucker_punch (2.1.2)
+      concurrent-ruby (~> 1.0)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -354,6 +356,7 @@ DEPENDENCIES
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
+  sucker_punch
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -228,13 +228,13 @@ class OrdersController < ApplicationController
   end
 
   def send_mail_new_order
-    OrderMailer.new_order_email(current_client).deliver
-    OrderMailer.new_order_email_notification(current_client).deliver
+    OrderMailer.new_order_email(current_client).deliver_later
+    OrderMailer.new_order_email_notification(current_client).deliver_later
   end
 
   def send_mail_deleted_order
-    OrderMailer.deleted_order_email(current_client).deliver
-    OrderMailer.deleted_order_email_notification(current_client).deliver
+    OrderMailer.deleted_order_email(current_client).deliver_later
+    OrderMailer.deleted_order_email_notification(current_client).deliver_later
   end
 
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,7 +9,7 @@ class PagesController < ApplicationController
   end
 
   def send_contact
-     ContactMailer.contact(params[:message], params[:email]).deliver
+     ContactMailer.contact(params[:message], params[:email]).deliver_later
      flash[:notice] = "Votre message a bien été envoyé !"
      redirect_back(fallback_location: root_path) # les messages flash Rails ne s'affichent qu'après rechargement de la page·
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ Bundler.require(*Rails.groups)
 
 module Goutsdfruits
   class Application < Rails::Application
+
+    # Setting back-end for Active Job to sucker_punch
+    config.active_job.queue_adapter = :sucker_punch
+
     # *Wagon lecture on Ajax - Unobtrusive JavaScript
     config.action_view.embed_authenticity_token_in_remote_forms = true
 


### PR DESCRIPTION
Gemfile: added sucker_punch
config/application.rb: set Active Job back-end to sucker_punch (queuing backend set-up used by ActiveJob for enqueuing and executing jobs in production)
orders_controller.rb & pages_controller.rb: OrderMailer & ContactMailer are now delivered_later by ActiveJob
